### PR TITLE
mdurlcheck: Accept absolute paths

### DIFF
--- a/mdurlcheck/main.go
+++ b/mdurlcheck/main.go
@@ -145,7 +145,7 @@ func processFile(name string, intrefs refMap) error {
 
 		if !exists(filename) {
 			hadErrors = true
-			log.Printf("%s: %q: broken link\n", name, dst)
+			log.Printf("%s: %q: broken link", name, dst)
 		}
 		if u.Fragment != "" && strings.HasSuffix(filename, ".md") {
 			okf, okr := intrefs.hasRef(filename, u.Fragment)

--- a/mdurlcheck/main.go
+++ b/mdurlcheck/main.go
@@ -135,10 +135,17 @@ func processFile(name string, intrefs refMap) error {
 		if u.Scheme != "" || u.Host != "" || u.Path == "" {
 			return ast.GoToNext
 		}
-		filename := filepath.Join(filepath.Dir(name), filepath.FromSlash(u.Path))
+
+		var filename string
+		if strings.HasPrefix(u.Path, "/") && false {
+			filename = filepath.Join(".", filepath.FromSlash(u.Path))
+		} else {
+			filename = filepath.Join(filepath.Dir(name), filepath.FromSlash(u.Path))
+		}
+
 		if !exists(filename) {
 			hadErrors = true
-			log.Printf("%s: %q: broken link", name, dst)
+			log.Printf("%s: %q: broken link\n", name, dst)
 		}
 		if u.Fragment != "" && strings.HasSuffix(filename, ".md") {
 			okf, okr := intrefs.hasRef(filename, u.Fragment)

--- a/testdata/broken.md
+++ b/testdata/broken.md
@@ -9,6 +9,7 @@
 * [Valid link](#html-link)
 * ![valid image](hello.md)
 * [Valid link](./hello.md)
+* [Valid link](/hello.md)
 * [Valid link](broken.md#mdurlcheck-test)
 * [Valid link to directory](../testdata)
 * [Valid link to second duplicate subheading](#duplicate-subheading-1)


### PR DESCRIPTION
mdserver supports absolute paths, but these get flagged by the mdurlcheck as invalid.

Example:

 * I want to write `/media/notification-aggregation4.png` instead of `../../media/notification-aggregation4.png`.