### PR TITLE
feat: add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: mdurlcheck
+    name: Check markdown URLs correctness
+    entry: mdurlcheck
+    language: golang
+    types: [markdown]


### PR DESCRIPTION
# Why?

Mostly quality of life. Having this as a proper hooks makes it so that I can have it auto-updated, frees people from having to think about installing mdtools, etc.

# How do I know it works?
```
pkoch@gato:~/github.com/Doist/doist-documentation
$ pre-commit try-repo ../../artyom/mdtools/ mdurlcheck -a
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../../artyom/mdtools
    rev: 9d66a0442be683094ec675849647e2b00b1ac5e3
    hooks:
    -   id: mdurlcheck
===============================================================================
[INFO] Initializing environment for ../../artyom/mdtools.
[INFO] Installing environment for ../../artyom/mdtools.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check markdown URLs correctness..........................................Passed
```